### PR TITLE
feat: add /init command to generate and load project context

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ export GROQ_API_KEY=your_api_key_here
 - `/model` - Select your Groq model
 - `/clear` - Clear chat history and context
 - `/reasoning` - Toggle display of reasoning content in messages
+- `/stats` - Display session statistics and token usage
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm run dev
 
 ### To Try it Out
 ```bash
-npx groq-code-cli@latest
+npm install -g groq-code-cli@latest
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ npm link        # Enables the `groq` command in any directory
 npm run dev  
 ```
 
-### To Try it Out
+### Run Instantly
+```bash
+# Using npx, no installation required
+npx groq-code-cli@latest
+```
+
+### Install Globally
 ```bash
 npm install -g groq-code-cli@latest
 ```

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Options:
   -t, --temperature <temp>      Temperature for generation (default: 1)
   -s, --system <message>        Custom system message
   -d, --debug                   Enable debug logging to debug-agent.log in current directory
+  -p, --proxy <url>             Proxy URL (e.g. http://proxy:8080 or socks5://proxy:1080)
   -h, --help                    Display help
   -V, --version                 Display version number
 ```
@@ -106,6 +107,22 @@ You can also set your API key for your current directory via environment variabl
 ```bash
 export GROQ_API_KEY=your_api_key_here
 ```
+
+### Proxy Configuration
+
+Supports HTTP/HTTPS/SOCKS5 proxies via CLI flag or environment variables:
+
+```bash
+# CLI flag (highest priority)
+groq --proxy http://proxy:8080
+groq --proxy socks5://proxy:1080
+
+# Environment variables
+export HTTP_PROXY=http://proxy:8080
+export HTTPS_PROXY=socks5://proxy:1080
+```
+
+Priority: `--proxy` > `HTTPS_PROXY` > `HTTP_PROXY`
 
 ### Available Commands
 - `/help` - Show help and available commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
 				"chalk": "^5.4.1",
 				"commander": "^14.0.0",
 				"groq-sdk": "^0.27.0",
+				"https-proxy-agent": "^7.0.6",
 				"ink": "^6.0.1",
 				"meow": "^11.0.0",
-				"react": "^19.1.0"
+				"react": "^19.1.0",
+				"socks-proxy-agent": "^8.0.5"
 			},
 			"bin": {
 				"groq": "dist/core/cli.js"
@@ -1213,6 +1215,15 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/agentkeepalive": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -2400,7 +2411,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
 			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -4338,6 +4348,19 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/human-signals": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
@@ -4664,6 +4687,25 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"license": "MIT",
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ip-address/node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/irregular-plurals": {
 			"version": "3.5.0",
@@ -5376,6 +5418,12 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
+		},
+		"node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+			"license": "MIT"
 		},
 		"node_modules/jsesc": {
 			"version": "3.1.0",
@@ -7500,6 +7548,44 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.6.tgz",
+			"integrity": "sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^9.0.5",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 	},
 	"scripts": {
 		"build": "tsc",
-		"dev": "tsc --watch"
+		"dev": "tsc --watch",
+		"test": "ava"
 	},
 	"files": [
 		"dist"
@@ -20,9 +21,11 @@
 		"chalk": "^5.4.1",
 		"commander": "^14.0.0",
 		"groq-sdk": "^0.27.0",
+		"https-proxy-agent": "^7.0.6",
 		"ink": "^6.0.1",
 		"meow": "^11.0.0",
-		"react": "^19.1.0"
+		"react": "^19.1.0",
+		"socks-proxy-agent": "^8.0.5"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^3.0.1",
@@ -46,6 +49,10 @@
 		},
 		"nodeArguments": [
 			"--loader=ts-node/esm"
+		],
+		"files": [
+			"src/**/*.test.ts",
+			"!**/*.d.ts"
 		]
 	},
 	"xo": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
 		"node": ">=16"
 	},
 	"scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "test": "ava"
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"test": "ava"
 	},
 	"files": [
 		"dist"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
 		"node": ">=16"
 	},
 	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch"
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "ava"
 	},
 	"files": [
 		"dist"

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -5,6 +5,13 @@ export interface CommandContext {
   setShowModelSelector?: (show: boolean) => void;
   toggleReasoning?: () => void;
   showReasoning?: boolean;
+  sessionStats?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+    totalRequests: number;
+    totalTime: number;
+  };
 }
 
 export interface CommandDefinition {

--- a/src/commands/definitions/init.ts
+++ b/src/commands/definitions/init.ts
@@ -1,0 +1,23 @@
+import { CommandDefinition, CommandContext } from '../base.js';
+import { writeProjectContext } from '../../utils/context.js';
+
+export const initCommand: CommandDefinition = {
+  command: 'init',
+  description: 'Generate project context files in .groq/',
+  handler: ({ addMessage }: CommandContext) => {
+    try {
+      const rootDir = process.env.GROQ_CONTEXT_DIR || process.cwd();
+      const { mdPath, jsonPath } = writeProjectContext(rootDir);
+      addMessage({
+        role: 'system',
+        content: `Project context generated.\n- Markdown: ${mdPath}\n- JSON: ${jsonPath}\nThe assistant will automatically load this context on startup. Re-run /init to refresh.`
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      addMessage({
+        role: 'system',
+        content: `Failed to generate project context: ${message}`
+      });
+    }
+  }
+};

--- a/src/commands/definitions/stats.ts
+++ b/src/commands/definitions/stats.ts
@@ -1,0 +1,23 @@
+import { CommandDefinition, CommandContext } from '../base.js';
+
+export const statsCommand: CommandDefinition = {
+  command: 'stats',
+  description: 'Display session statistics and token usage',
+  handler: ({ addMessage, sessionStats }: CommandContext) => {
+    addMessage({
+      role: 'system',
+      content: 'SHOW_STATS',
+      type: 'stats',
+      usageSnapshot: sessionStats ? {
+        prompt_tokens: sessionStats.promptTokens,
+        completion_tokens: sessionStats.completionTokens,
+        total_tokens: sessionStats.totalTokens,
+        total_requests: sessionStats.totalRequests,
+        total_time: sessionStats.totalTime,
+        queue_time: 0,
+        prompt_time: 0,
+        completion_time: 0,
+      } : undefined
+    });
+  }
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ import { loginCommand } from './definitions/login.js';
 import { modelCommand } from './definitions/model.js';
 import { clearCommand } from './definitions/clear.js';
 import { reasoningCommand } from './definitions/reasoning.js';
+import { statsCommand } from './definitions/stats.js';
 
 const availableCommands: CommandDefinition[] = [
   helpCommand,
@@ -11,6 +12,7 @@ const availableCommands: CommandDefinition[] = [
   modelCommand,
   clearCommand,
   reasoningCommand,
+  statsCommand,
 ];
 
 export function getAvailableCommands(): CommandDefinition[] {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,6 +3,7 @@ import { helpCommand } from './definitions/help.js';
 import { loginCommand } from './definitions/login.js';
 import { modelCommand } from './definitions/model.js';
 import { clearCommand } from './definitions/clear.js';
+import { initCommand } from './definitions/init.js';
 import { reasoningCommand } from './definitions/reasoning.js';
 
 const availableCommands: CommandDefinition[] = [
@@ -10,6 +11,7 @@ const availableCommands: CommandDefinition[] = [
   loginCommand,
   modelCommand,
   clearCommand,
+  initCommand,
   reasoningCommand,
 ];
 

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -28,7 +28,7 @@ export class Agent {
   private onThinkingText?: (content: string, reasoning?: string) => void;
   private onFinalMessage?: (content: string, reasoning?: string) => void;
   private onMaxIterations?: (maxIterations: number) => Promise<boolean>;
-  private onApiUsage?: (usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number }) => void;
+  private onApiUsage?: (usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number; total_time?: number }) => void;
   private requestCount: number = 0;
   private currentAbortController: AbortController | null = null;
   private isInterrupted: boolean = false;
@@ -138,7 +138,7 @@ When asked about your identity, you should identify yourself as a coding assista
     onThinkingText?: (content: string) => void;
     onFinalMessage?: (content: string) => void;
     onMaxIterations?: (maxIterations: number) => Promise<boolean>;
-    onApiUsage?: (usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number }) => void;
+    onApiUsage?: (usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number; total_time?: number }) => void;
   }) {
     this.onToolStart = callbacks.onToolStart;
     this.onToolEnd = callbacks.onToolEnd;
@@ -311,7 +311,8 @@ When asked about your identity, you should identify yourself as a coding assista
             this.onApiUsage({
               prompt_tokens: response.usage.prompt_tokens,
               completion_tokens: response.usage.completion_tokens,
-              total_tokens: response.usage.total_tokens
+              total_tokens: response.usage.total_tokens,
+              total_time: response.usage.total_time
             });
           }
           debugLog('Message content length:', message.content?.length || 0);

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -55,6 +55,27 @@ export class Agent {
 
     // Add system message to conversation
     this.messages.push({ role: 'system', content: this.systemMessage });
+
+    // Load project context if available
+    try {
+      const explicitContextFile = process.env.GROQ_CONTEXT_FILE;
+      const baseDir = process.env.GROQ_CONTEXT_DIR || process.cwd();
+      const contextPath = explicitContextFile || path.join(baseDir, '.groq', 'context.md');
+      const contextLimit = parseInt(process.env.GROQ_CONTEXT_LIMIT || '20000', 10);
+      if (fs.existsSync(contextPath)) {
+        const ctx = fs.readFileSync(contextPath, 'utf-8');
+        const trimmed = ctx.length > contextLimit ? ctx.slice(0, contextLimit) + '\n... [truncated]' : ctx;
+        const contextSource = explicitContextFile ? contextPath : '.groq/context.md';
+        this.messages.push({
+          role: 'system',
+          content: `Project context loaded from ${contextSource}. Use this as high-level reference when reasoning about the repository.\n\n${trimmed}`
+        });
+      }
+    } catch (error) {
+      if (debugEnabled) {
+        debugLog('Failed to load project context:', error);
+      }
+    }
   }
 
   static async create(

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -8,10 +8,23 @@ import App from '../ui/App.js';
 
 const program = new Command();
 
+/**
+ * Start the interactive terminal chat UI by creating an Agent and rendering the Ink App.
+ *
+ * Initializes an AI agent with the given temperature, optional system prompt, debug mode, and optional proxy,
+ * prints the CLI banner, validates the proxy URL (if provided), then renders the React/Ink UI. On invalid proxy
+ * or on initialization errors the process exits with code 1.
+ *
+ * @param temperature - Sampling temperature used for model generation.
+ * @param system - Optional system message to seed the agent's context; pass `null` to use defaults.
+ * @param debug - When true, enables debug logging for the agent.
+ * @param proxy - Optional proxy URL to route requests through (e.g., `http://proxy:8080` or `socks5://proxy:1080`).
+ */
 async function startChat(
   temperature: number,
   system: string | null,
-  debug?: boolean
+  debug?: boolean,
+  proxy?: string
 ): Promise<void> {
   console.log(chalk.hex('#FF4500')(`                             
   ██████    ██████   ██████   ██████
@@ -34,9 +47,22 @@ async function startChat(
 `));
     
   let defaultModel = 'moonshotai/kimi-k2-instruct';
+  
+  // Validate proxy URL if provided
+  if (proxy) {
+    try {
+      new URL(proxy);
+    } catch (error) {
+      // Don't display the actual URL in case it contains credentials
+      console.log(chalk.red('Invalid proxy URL provided'));
+      console.log(chalk.yellow('Proxy URL must be a valid URL (e.g., http://proxy:8080 or socks5://proxy:1080)'));
+      process.exit(1);
+    }
+  }
+  
   try {
     // Create agent (API key will be checked on first message)
-    const agent = await Agent.create(defaultModel, temperature, system, debug);
+    const agent = await Agent.create(defaultModel, temperature, system, debug, proxy);
 
     render(React.createElement(App, { agent }));
   } catch (error) {
@@ -52,11 +78,13 @@ program
   .option('-t, --temperature <temperature>', 'Temperature for generation', parseFloat, 1.0)
   .option('-s, --system <message>', 'Custom system message')
   .option('-d, --debug', 'Enable debug logging to debug-agent.log in current directory')
+  .option('-p, --proxy <url>', 'Proxy URL (e.g. http://proxy:8080 or socks5://proxy:1080)')
   .action(async (options) => {
     await startChat(
       options.temperature,
       options.system || null,
-      options.debug
+      options.debug,
+      options.proxy
     );
   });
 

--- a/src/tests/proxy-config.test.ts
+++ b/src/tests/proxy-config.test.ts
@@ -1,0 +1,186 @@
+import test from 'ava';
+import { getProxyAgent, getProxyInfo } from '../utils/proxy-config.js';
+
+// Helper to set and restore environment variables
+function withEnv(env: Record<string, string | undefined>, fn: () => void) {
+  const original: Record<string, string | undefined> = {};
+  
+  // Save original values
+  for (const key of Object.keys(env)) {
+    original[key] = process.env[key];
+  }
+  
+  // Set new values
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  
+  try {
+    fn();
+  } finally {
+    // Restore original values
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test('getProxyInfo returns disabled when no proxy is configured', t => {
+  withEnv({ HTTP_PROXY: undefined, HTTPS_PROXY: undefined, http_proxy: undefined, https_proxy: undefined }, () => {
+    const info = getProxyInfo();
+    t.is(info.enabled, false);
+    t.is(info.url, undefined);
+    t.is(info.type, undefined);
+  });
+});
+
+test('getProxyInfo detects HTTP_PROXY environment variable', t => {
+  withEnv({ HTTP_PROXY: 'http://proxy.example.com:8080', HTTPS_PROXY: undefined }, () => {
+    const info = getProxyInfo();
+    t.is(info.enabled, true);
+    t.is(info.url, 'http://proxy.example.com:8080');
+    t.is(info.type, 'http');
+  });
+});
+
+test('getProxyInfo detects HTTPS_PROXY environment variable', t => {
+  withEnv({ HTTPS_PROXY: 'http://secure-proxy.example.com:8443', HTTP_PROXY: undefined }, () => {
+    const info = getProxyInfo();
+    t.is(info.enabled, true);
+    t.is(info.url, 'http://secure-proxy.example.com:8443');
+    t.is(info.type, 'http');
+  });
+});
+
+test('getProxyInfo prefers HTTPS_PROXY over HTTP_PROXY', t => {
+  withEnv({ 
+    HTTPS_PROXY: 'http://secure-proxy.example.com:8443',
+    HTTP_PROXY: 'http://proxy.example.com:8080'
+  }, () => {
+    const info = getProxyInfo();
+    t.is(info.enabled, true);
+    t.is(info.url, 'http://secure-proxy.example.com:8443');
+    t.is(info.type, 'http');
+  });
+});
+
+test('getProxyInfo detects SOCKS5 proxy from URL scheme', t => {
+  withEnv({ HTTP_PROXY: 'socks5://socks-proxy.example.com:1080', HTTPS_PROXY: undefined }, () => {
+    const info = getProxyInfo();
+    t.is(info.enabled, true);
+    t.is(info.url, 'socks5://socks-proxy.example.com:1080');
+    t.is(info.type, 'socks');
+  });
+});
+
+test('getProxyInfo detects SOCKS proxy (without version) from URL scheme', t => {
+  withEnv({ HTTP_PROXY: 'socks://socks-proxy.example.com:1080', HTTPS_PROXY: undefined }, () => {
+    const info = getProxyInfo();
+    t.is(info.enabled, true);
+    t.is(info.url, 'socks://socks-proxy.example.com:1080');
+    t.is(info.type, 'socks');
+  });
+});
+
+test('getProxyInfo respects lowercase environment variables', t => {
+  withEnv({ 
+    http_proxy: 'http://proxy.example.com:3128',
+    https_proxy: 'http://secure-proxy.example.com:3128',
+    HTTP_PROXY: undefined,
+    HTTPS_PROXY: undefined
+  }, () => {
+    const info = getProxyInfo();
+    t.is(info.enabled, true);
+    t.is(info.url, 'http://secure-proxy.example.com:3128');
+    t.is(info.type, 'http');
+  });
+});
+
+test('getProxyInfo uses proxy override when provided', t => {
+  withEnv({ HTTP_PROXY: 'http://env-proxy.example.com:8080' }, () => {
+    const info = getProxyInfo('http://override-proxy.example.com:9090');
+    t.is(info.enabled, true);
+    t.is(info.url, 'http://override-proxy.example.com:9090');
+    t.is(info.type, 'http');
+  });
+});
+
+test('getProxyInfo detects SOCKS proxy type in override', t => {
+  withEnv({ HTTP_PROXY: 'http://env-proxy.example.com:8080' }, () => {
+    const info = getProxyInfo('socks5://override-socks.example.com:1080');
+    t.is(info.enabled, true);
+    t.is(info.url, 'socks5://override-socks.example.com:1080');
+    t.is(info.type, 'socks');
+  });
+});
+
+test('getProxyAgent returns undefined when no proxy is configured', t => {
+  withEnv({ HTTP_PROXY: undefined, HTTPS_PROXY: undefined }, () => {
+    const agent = getProxyAgent();
+    t.is(agent, undefined);
+  });
+});
+
+test('getProxyAgent creates HttpsProxyAgent for HTTP proxy', t => {
+  withEnv({ HTTP_PROXY: 'http://proxy.example.com:8080' }, () => {
+    const agent = getProxyAgent();
+    t.not(agent, undefined);
+    // Check that it's an HttpsProxyAgent instance
+    t.truthy(agent);
+  });
+});
+
+test('getProxyAgent creates SocksProxyAgent for SOCKS5 proxy', t => {
+  withEnv({ HTTP_PROXY: 'socks5://socks-proxy.example.com:1080' }, () => {
+    const agent = getProxyAgent();
+    t.not(agent, undefined);
+    // Check that it's a SocksProxyAgent instance
+    t.truthy(agent);
+  });
+});
+
+test('getProxyAgent uses override when provided', t => {
+  withEnv({ HTTP_PROXY: 'http://env-proxy.example.com:8080' }, () => {
+    const agent = getProxyAgent('http://override-proxy.example.com:9090');
+    t.not(agent, undefined);
+    t.truthy(agent);
+  });
+});
+
+test('getProxyAgent creates correct agent for SOCKS override', t => {
+  withEnv({ HTTP_PROXY: 'http://env-proxy.example.com:8080' }, () => {
+    const agent = getProxyAgent('socks5://override-socks.example.com:1080');
+    t.not(agent, undefined);
+    t.truthy(agent);
+  });
+});
+
+test('getProxyInfo sanitizes proxy URLs with credentials', t => {
+  const info = getProxyInfo('http://user:pass@proxy.example.com:8080');
+  t.is(info.enabled, true);
+  t.is(info.url, 'http://proxy.example.com:8080/');
+  t.is(info.type, 'http');
+});
+
+test('getProxyAgent handles invalid proxy URLs gracefully', t => {
+  const agent = getProxyAgent('not-a-valid-url');
+  t.is(agent, undefined);
+});
+
+test('getProxyInfo handles malformed URLs safely', t => {
+  const info = getProxyInfo('http://user@:pass@@proxy:8080');
+  t.is(info.enabled, true);
+  // Should return sanitized version or safe message
+  t.truthy(info.url);
+  if (info.url) {
+    t.not(info.url.includes('pass'), 'Password should be removed');
+  }
+});

--- a/src/ui/components/core/MessageHistory.tsx
+++ b/src/ui/components/core/MessageHistory.tsx
@@ -2,14 +2,27 @@ import React, { useEffect, useRef } from 'react';
 import { Box, Text } from 'ink';
 import { ChatMessage } from '../../hooks/useAgent.js';
 import ToolHistoryItem from '../display/ToolHistoryItem.js';
+import Stats from '../display/Stats.js';
 import { parseMarkdown, MarkdownElement, parseInlineElements } from '../../../utils/markdown.js';
+
+interface Usage {
+  queue_time: number;
+  prompt_tokens: number;
+  prompt_time: number;
+  completion_tokens: number;
+  completion_time: number;
+  total_tokens: number;
+  total_requests?: number;
+  total_time: number;
+}
 
 interface MessageHistoryProps {
   messages: ChatMessage[];
   showReasoning?: boolean;
+  usageData?: Usage;
 }
 
-export default function MessageHistory({ messages, showReasoning = true }: MessageHistoryProps) {
+export default function MessageHistory({ messages, showReasoning = true, usageData }: MessageHistoryProps) {
   const scrollRef = useRef<any>(null);
 
   // Auto-scroll to bottom when new messages are added
@@ -92,6 +105,15 @@ export default function MessageHistory({ messages, showReasoning = true }: Messa
         );
         
       case 'system':
+        // Handle special system message types
+        if (message.type === 'stats') {
+          return (
+            <Box key={message.id} marginBottom={1}>
+              <Stats usage={message.usageSnapshot || usageData} />
+            </Box>
+          );
+        }
+        
         return (
           <Box key={message.id} marginBottom={1}>
             <Text color="yellow" italic>

--- a/src/ui/components/display/Stats.tsx
+++ b/src/ui/components/display/Stats.tsx
@@ -1,0 +1,93 @@
+import { Box, Text } from 'ink';
+
+interface Usage {
+  queue_time: number;
+  prompt_tokens: number;
+  prompt_time: number;
+  completion_tokens: number;
+  completion_time: number;
+  total_tokens: number;
+  total_requests?: number;
+  total_time: number;
+  prompt_tokens_details?: {
+    cached_tokens: number;
+  };
+}
+
+interface StatsProps {
+  usage?: Usage;
+}
+
+export default function Stats({ usage }: StatsProps) {
+  const formatTime = (seconds: number): string => {
+    if (seconds < 1) {
+      return `${(seconds * 1000).toFixed(0)}ms`;
+    } else if (seconds < 60) {
+      return `${seconds.toFixed(1)}s`;
+    } else {
+      const minutes = Math.floor(seconds / 60);
+      const remainingSeconds = seconds % 60;
+      return `${minutes}m ${remainingSeconds.toFixed(1)}s`;
+    }
+  };
+
+  // Extract values from API response
+  const cachedTokens = usage?.prompt_tokens_details?.cached_tokens || 0;
+  const promptTokens = usage?.prompt_tokens || 0;
+  const cachedPercent = promptTokens > 0 ? ((cachedTokens / promptTokens) * 100).toFixed(1) : 0;
+
+  const stats = {
+    totalRequests: usage?.total_requests || 0,
+    processingTime: formatTime(usage?.total_time || 0),
+    promptTokens: promptTokens,
+    completionTokens: usage?.completion_tokens || 0,
+    cachedTokens,
+    cachedPercent,
+  };
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Box marginBottom={1}>
+        <Text color="cyan" bold>📊 Session Stats</Text>
+      </Box>
+      
+      <Box flexDirection="column" marginBottom={2}>
+        <Box justifyContent="flex-start" marginBottom={1} borderStyle="single" borderColor="gray" borderTop={false} borderLeft={false} borderRight={false} paddingBottom={0}>
+          <Text color="gray">Performance</Text>
+        </Box>
+        <Box flexDirection="row" justifyContent="center" gap={4}>
+          <Box flexDirection="column" alignItems="center" paddingX={3}>
+            <Text color="blue" bold>{stats.totalRequests}</Text>
+            <Text color="gray" dimColor>Requests</Text>
+          </Box>
+          <Box flexDirection="column" alignItems="center" paddingX={3}>
+            <Text color="yellow" bold>{stats.processingTime}</Text>
+            <Text color="gray" dimColor>Response Time</Text>
+          </Box>
+        </Box>
+      </Box>
+      
+      <Box flexDirection="column">
+        <Box justifyContent="flex-start" marginBottom={1} borderStyle="single" borderColor="gray" borderTop={false} borderLeft={false} borderRight={false} paddingBottom={0}>
+          <Text color="gray">Token Usage</Text>
+        </Box>
+        <Box flexDirection="row" justifyContent="center" gap={4}>
+          <Box flexDirection="column" alignItems="center" paddingX={3}>
+            <Text color="cyan" bold>{stats.promptTokens.toLocaleString()}</Text>
+            <Text color="gray" dimColor>Input Tokens</Text>
+          </Box>
+          <Box flexDirection="column" alignItems="center" paddingX={3}>
+            <Text color="green" bold>{stats.completionTokens.toLocaleString()}</Text>
+            <Text color="gray" dimColor>Output Tokens</Text>
+          </Box>
+          {usage?.prompt_tokens_details && (
+            <Box flexDirection="column" alignItems="center" paddingX={3}>
+              <Text color="magenta" bold>{stats.cachedTokens.toLocaleString()} ({stats.cachedPercent}%)</Text>
+              <Text color="gray" dimColor>Cached</Text>
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/input-overlays/ErrorRetry.tsx
+++ b/src/ui/components/input-overlays/ErrorRetry.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+interface ErrorRetryProps {
+  error: string;
+  onRetry: () => void;
+  onCancel: () => void;
+}
+
+export default function ErrorRetry({ error, onRetry, onCancel }: ErrorRetryProps) {
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="red" paddingX={1} paddingY={1}>
+      <Box marginBottom={1}>
+        <Text color="red" bold>
+          ❌ An error occurred:
+        </Text>
+      </Box>
+      
+      <Box marginBottom={2} flexWrap="wrap">
+        <Text color="red">
+          {error}
+        </Text>
+      </Box>
+      
+      <Box justifyContent="space-between">
+        <Box>
+          <Text color="green" bold>
+            [R]etry
+          </Text>
+          <Text color="gray"> - Try the request again</Text>
+        </Box>
+        <Box>
+          <Text color="red" bold>
+            [C]ancel
+          </Text>
+          <Text color="gray"> - Stop and return to input</Text>
+        </Box>
+      </Box>
+      
+      <Box marginTop={1}>
+        <Text color="gray" dimColor>
+          Press R to retry or C to cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/hooks/useAgent.ts
+++ b/src/ui/hooks/useAgent.ts
@@ -9,6 +9,17 @@ export interface ChatMessage {
   reasoning?: string;
   timestamp: Date;
   toolExecution?: ToolExecution;
+  type?: string;
+  usageSnapshot?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    total_requests: number;
+    total_time: number;
+    queue_time: number;
+    prompt_time: number;
+    completion_time: number;
+  };
 }
 
 export interface ToolExecution {
@@ -23,7 +34,7 @@ export interface ToolExecution {
 export function useAgent(
   agent: Agent, 
   onStartRequest?: () => void,
-  onAddApiTokens?: (usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number }) => void, 
+  onAddApiTokens?: (usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number; total_time?: number }) => void, 
   onPauseRequest?: () => void,
   onResumeRequest?: () => void,
   onCompleteRequest?: () => void
@@ -152,7 +163,7 @@ export function useAgent(
           setCurrentToolExecution(null);
           currentExecutionIdRef.current = null;
         },
-        onApiUsage: (usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number }) => {
+        onApiUsage: (usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number; total_time?: number }) => {
           // Pass API usage data to token metrics
           if (onAddApiTokens) {
             onAddApiTokens(usage);

--- a/src/ui/hooks/useSessionStats.ts
+++ b/src/ui/hooks/useSessionStats.ts
@@ -1,0 +1,54 @@
+import { useState, useCallback } from 'react';
+
+interface ApiUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  total_time?: number;
+}
+
+interface SessionStats {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  totalRequests: number;
+  totalTime: number;
+}
+
+export function useSessionStats() {
+  const [sessionStats, setSessionStats] = useState<SessionStats>({
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    totalRequests: 0,
+    totalTime: 0,
+  });
+
+  // Add tokens from an API response to the cumulative session totals
+  const addSessionTokens = useCallback((usage: ApiUsage) => {
+    setSessionStats(prev => ({
+      promptTokens: prev.promptTokens + usage.prompt_tokens,
+      completionTokens: prev.completionTokens + usage.completion_tokens,
+      totalTokens: prev.totalTokens + usage.total_tokens,
+      totalRequests: prev.totalRequests + 1, // Increment request count
+      totalTime: prev.totalTime + (usage.total_time || 0), // Accumulate processing time
+    }));
+  }, []);
+
+  // Clear session stats (called when chat history is cleared)
+  const clearSessionStats = useCallback(() => {
+    setSessionStats({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      totalRequests: 0,
+      totalTime: 0,
+    });
+  }, []);
+
+  return {
+    sessionStats,
+    addSessionTokens,
+    clearSessionStats,
+  };
+}

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,0 +1,304 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { shouldIgnore } from './file-ops.js';
+
+export interface ProjectContextJson {
+  generated_at: string;
+  root: string;
+  summary: {
+    total_files: number;
+    total_directories: number;
+    languages: Array<{ extension: string; files: number }>;
+  };
+  package?: {
+    name?: string;
+    version?: string;
+    description?: string;
+    scripts?: string[];
+    dependencies_count?: number;
+    dev_dependencies_count?: number;
+  };
+  config_files: string[];
+  notable_files: string[];
+  tree: string[]; // directory tree lines
+}
+
+export interface GenerateContextOptions {
+  maxDepth?: number; // max directory depth to traverse
+  maxEntries?: number; // max number of files/dirs to include in tree
+}
+
+const DEFAULT_OPTIONS: Required<GenerateContextOptions> = {
+  maxDepth: 3,
+  maxEntries: 1500,
+};
+
+export function generateProjectContext(rootDir: string = process.cwd(), options: GenerateContextOptions = {}): { json: ProjectContextJson; markdown: string } {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const root = path.resolve(rootDir);
+  // Validate root directory exists and is accessible
+  let rootStat: fs.Stats;
+  try {
+    rootStat = fs.statSync(root);
+  } catch {
+    throw new Error(`Root directory does not exist or is not accessible: ${root}`);
+  }
+  if (!rootStat.isDirectory()) {
+    throw new Error(`Root path is not a directory: ${root}`);
+  }
+
+  const stats = walkDirectory(root, opts.maxDepth, opts.maxEntries);
+
+  const languages = Object.entries(stats.extensionCounts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([ext, count]) => ({ extension: ext || '(none)', files: count }));
+
+  const pkg = readPackageJson(root);
+
+  const configFiles = stats.allFiles
+    .filter(fp => isConfigFile(fp))
+    .map(fp => path.relative(root, fp))
+    .sort();
+
+  const notableFiles = stats.allFiles
+    .filter(fp => isNotableFile(fp))
+    .map(fp => path.relative(root, fp))
+    .sort();
+
+  const treeLines = renderTree(stats.treeNodes);
+
+  const json: ProjectContextJson = {
+    generated_at: new Date().toISOString(),
+    root,
+    summary: {
+      total_files: stats.fileCount,
+      total_directories: stats.dirCount,
+      languages,
+    },
+    package: pkg || undefined,
+    config_files: configFiles,
+    notable_files: notableFiles,
+    tree: treeLines,
+  };
+
+  const markdown = buildMarkdown(json);
+
+  return { json, markdown };
+}
+
+export function writeProjectContext(rootDir: string = process.cwd(), options: GenerateContextOptions = {}): { mdPath: string; jsonPath: string } {
+  const { json, markdown } = generateProjectContext(rootDir, options);
+
+  const outputDir = path.join(rootDir, '.groq');
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const mdPath = path.join(outputDir, 'context.md');
+  const jsonPath = path.join(outputDir, 'context.json');
+
+  fs.writeFileSync(mdPath, markdown, 'utf-8');
+  fs.writeFileSync(jsonPath, JSON.stringify(json, null, 2), 'utf-8');
+
+  return { mdPath, jsonPath };
+}
+
+function readPackageJson(rootDir: string): ProjectContextJson['package'] | null {
+  const pkgPath = path.join(rootDir, 'package.json');
+  try {
+    if (!fs.existsSync(pkgPath)) return null;
+    const raw = fs.readFileSync(pkgPath, 'utf-8');
+    const pkg = JSON.parse(raw);
+    return {
+      name: pkg.name,
+      version: pkg.version,
+      description: pkg.description,
+      scripts: pkg.scripts ? Object.keys(pkg.scripts) : [],
+      dependencies_count: pkg.dependencies ? Object.keys(pkg.dependencies).length : 0,
+      dev_dependencies_count: pkg.devDependencies ? Object.keys(pkg.devDependencies).length : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isConfigFile(filePath: string): boolean {
+  const base = path.basename(filePath).toLowerCase();
+  const configNames = new Set([
+    'package.json', 'tsconfig.json', 'jsconfig.json', 'pyproject.toml', 'poetry.lock', 'requirements.txt',
+    'go.mod', 'go.sum', 'cargo.toml', 'cargo.lock', 'composer.json', 'composer.lock', 'gemfile', 'gemfile.lock',
+    'pipfile', 'pipfile.lock', 'dockerfile', 'docker-compose.yml', '.dockerignore', '.gitignore', '.env', '.editorconfig',
+    '.eslintrc', '.eslintrc.js', '.prettierrc', '.prettierrc.js', 'makefile', 'justfile',
+  ]);
+  return configNames.has(base);
+}
+
+function isNotableFile(filePath: string): boolean {
+  const base = path.basename(filePath).toLowerCase();
+  return base.startsWith('readme') || base === 'license' || base === 'license.md' || base.endsWith('.md');
+}
+
+interface TreeNode {
+  name: string;
+  path: string;
+  isDir: boolean;
+  children: TreeNode[];
+}
+
+function walkDirectory(root: string, maxDepth: number, maxEntries: number): {
+  treeNodes: TreeNode[];
+  fileCount: number;
+  dirCount: number;
+  extensionCounts: Record<string, number>;
+  allFiles: string[];
+} {
+  let fileCount = 0;
+  let dirCount = 0;
+  let totalEntries = 0;
+  const extensionCounts: Record<string, number> = {};
+  const allFiles: string[] = [];
+
+  function isDirectorySafe(p: string): boolean {
+    try {
+      return fs.statSync(p).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  function walk(current: string, depth: number): TreeNode | null {
+    if (depth > maxDepth) return null;
+    if (totalEntries >= maxEntries) return null;
+
+    const name = path.basename(current);
+    let isDir = false;
+    try {
+      const stat = fs.statSync(current);
+      isDir = stat.isDirectory();
+    } catch {
+      // File might have been deleted or is inaccessible
+      return null;
+    }
+
+    if (depth === 0 && shouldIgnore(current)) {
+      // Do not ignore the root itself; only skip if ignore would exclude it intentionally.
+    }
+
+    if (depth > 0 && shouldIgnore(current)) {
+      return null;
+    }
+
+    const node: TreeNode = { name, path: current, isDir, children: [] };
+    totalEntries++;
+
+    if (isDir) {
+      dirCount++;
+      let entries: string[] = [];
+      try {
+        entries = fs.readdirSync(current).map(e => path.join(current, e));
+      } catch {
+        entries = [];
+      }
+      // Sort: dirs first then files alphabetically
+      entries.sort((a, b) => {
+        const aDir = isDirectorySafe(a);
+        const bDir = isDirectorySafe(b);
+        if (aDir !== bDir) return aDir ? -1 : 1;
+        return path.basename(a).toLowerCase().localeCompare(path.basename(b).toLowerCase());
+      });
+
+      for (const entry of entries) {
+        if (totalEntries >= maxEntries) break;
+        const child = walk(entry, depth + 1);
+        if (child) node.children.push(child);
+      }
+    } else {
+      fileCount++;
+      allFiles.push(current);
+      const ext = path.extname(name).replace(/^\./, '');
+      extensionCounts[ext] = (extensionCounts[ext] || 0) + 1;
+    }
+
+    return node;
+  }
+
+  const rootEntries = fs.readdirSync(root).map(e => path.join(root, e));
+  const nodes: TreeNode[] = [];
+  for (const entry of rootEntries) {
+    if (totalEntries >= maxEntries) break;
+    const child = walk(entry, 1);
+    if (child) nodes.push(child);
+  }
+
+  return { treeNodes: nodes, fileCount, dirCount, extensionCounts, allFiles };
+}
+
+function renderTree(nodes: TreeNode[]): string[] {
+  const lines: string[] = [];
+
+  function render(node: TreeNode, prefix: string, isLast: boolean) {
+    const connector = prefix ? (isLast ? '└── ' : '├── ') : '';
+    const name = node.isDir ? `${node.name}/` : node.name;
+    lines.push(`${prefix}${connector}${name}`);
+
+    const childPrefix = prefix + (prefix ? (isLast ? '    ' : '│   ') : '');
+    node.children.forEach((child, index) => {
+      const last = index === node.children.length - 1;
+      render(child, childPrefix, last);
+    });
+  }
+
+  nodes.forEach((n, idx) => render(n, '', idx === nodes.length - 1));
+  return lines;
+}
+
+function buildMarkdown(ctx: ProjectContextJson): string {
+  const lines: string[] = [];
+  lines.push(`# Project Context`);
+  lines.push('');
+  lines.push(`Generated: ${ctx.generated_at}`);
+  lines.push('');
+  lines.push(`Root: ${ctx.root}`);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push(`- Files: ${ctx.summary.total_files}`);
+  lines.push(`- Directories: ${ctx.summary.total_directories}`);
+  if (ctx.package) {
+    lines.push(`- Package: ${ctx.package.name || ''} ${ctx.package.version ? `v${ctx.package.version}` : ''}`.trim());
+    if (ctx.package.description) lines.push(`- Description: ${ctx.package.description}`);
+    lines.push(`- Scripts: ${ctx.package.scripts?.length || 0}`);
+    lines.push(`- Dependencies: ${ctx.package.dependencies_count || 0}`);
+    lines.push(`- Dev Dependencies: ${ctx.package.dev_dependencies_count || 0}`);
+  }
+  lines.push('');
+  lines.push('## Languages (by file count)');
+  const langLines = ctx.summary.languages.slice(0, 12).map(l =>
+    l.extension === '(none)'
+      ? `- ${l.extension}: ${l.files}`
+      : `- .${l.extension}: ${l.files}`
+  );
+  lines.push(...(langLines.length ? langLines : ['- (no code files detected)']));
+
+  if (ctx.config_files.length) {
+    lines.push('');
+    lines.push('## Configuration Files');
+    ctx.config_files.forEach(f => lines.push(`- ${f}`));
+  }
+
+  if (ctx.notable_files.length) {
+    lines.push('');
+    lines.push('## Notable Files');
+    ctx.notable_files.forEach(f => lines.push(`- ${f}`));
+  }
+
+  if (ctx.tree.length) {
+    lines.push('');
+    lines.push('## Directory Tree');
+    lines.push('```');
+    ctx.tree.forEach(l => lines.push(l));
+    lines.push('```');
+  }
+
+  lines.push('');
+  lines.push('---');
+  lines.push('This file is auto-generated. Re-run the init command to refresh.');
+  return lines.join('\n');
+}

--- a/src/utils/proxy-config.ts
+++ b/src/utils/proxy-config.ts
@@ -1,0 +1,156 @@
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { SocksProxyAgent } from 'socks-proxy-agent';
+import type { Agent } from 'http';
+import { ConfigManager } from './local-settings.js';
+
+// Module-level instance to avoid repeated instantiation
+const configManager = new ConfigManager();
+
+/**
+ * Resolves the proxy URL to use from an explicit override, environment variables, or config file.
+ *
+ * If `proxyOverride` is provided it is returned directly. Otherwise the function
+ * returns the first non-empty value found in priority order:
+ * GROQ_PROXY > HTTPS_PROXY/https_proxy > HTTP_PROXY/http_proxy > config file.
+ * If none are set, returns undefined.
+ *
+ * @param proxyOverride - Optional explicit proxy URL that takes precedence over env vars and config.
+ * @returns The resolved proxy URL string, or `undefined` if no proxy is configured.
+ */
+function getProxyUrl(proxyOverride?: string): string | undefined {
+  if (proxyOverride) {
+    return proxyOverride;
+  }
+  
+  // Check for proxy environment variables first (in order of priority)
+  // Check GROQ_PROXY first, then standard environment variables
+  const groqProxy = process.env.GROQ_PROXY;
+  const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
+  
+  // Priority: GROQ_PROXY > HTTPS_PROXY > HTTP_PROXY > config file
+  if (groqProxy || httpsProxy || httpProxy) {
+    return groqProxy || httpsProxy || httpProxy;
+  }
+  
+  // If no environment variable, check config file
+  return configManager.getProxy() || undefined;
+}
+
+/**
+ * Determine whether a proxy URL refers to a SOCKS proxy or an HTTP(S) proxy.
+ *
+ * Recognizes `socks://`, `socks5://`, and `socks4://` schemes as SOCKS; any other scheme is treated as HTTP.
+ *
+ * @param url - The proxy URL or scheme string to inspect.
+ * @returns `'socks'` if the URL uses a SOCKS scheme, otherwise `'http'`.
+ */
+function getProxyType(url: string): 'socks' | 'http' {
+  if (url.startsWith('socks://') || url.startsWith('socks5://') || url.startsWith('socks4://') || url.startsWith('socks4a://')) {
+    return 'socks';
+  }
+  return 'http';
+}
+
+/**
+ * Returns a proxy URL safe for logging by removing any embedded credentials.
+ *
+ * Attempts to parse the input as a URL and, if username or password are present,
+ * returns a sanitized string with credentials removed. If parsing fails and the
+ * input appears to contain credentials (contains '@'), returns the literal
+ * "[proxy with credentials]" to avoid exposing secrets; otherwise returns the
+ * original input unchanged.
+ *
+ * @param url - The proxy URL to sanitize; may include credentials (e.g., `user:pass@host`).
+ * @returns A sanitized URL string suitable for logging or the original input when no sanitization is needed.
+ */
+function sanitizeProxyUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.username || parsed.password) {
+      parsed.username = '';
+      parsed.password = '';
+      return parsed.toString();
+    }
+    return url;
+  } catch {
+    // If URL parsing fails, return a safe message
+    return url.includes('@') ? '[proxy with credentials]' : url;
+  }
+}
+
+/**
+ * Checks whether a string is a valid URL suitable for a proxy.
+ *
+ * Attempts to parse the provided `url` using the WHATWG URL parser and
+ * returns true if parsing succeeds, false otherwise.
+ *
+ * @param url - The candidate proxy URL string to validate.
+ * @returns True when `url` can be parsed as a valid URL; otherwise false.
+ */
+function isValidProxyUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Creates an HTTP/SOCKS proxy agent based on an explicit override or environment variables.
+ *
+ * Resolves a proxy URL (override -> HTTPS_PROXY/https_proxy -> HTTP_PROXY/http_proxy). If no proxy is configured, returns `undefined`. If the resolved URL is not a valid URL, the function logs an error and returns `undefined`. Otherwise it returns a `SocksProxyAgent` for SOCKS schemes (`socks://`, `socks5://`, `socks4://`) or an `HttpsProxyAgent` for other schemes. If agent construction fails the error is logged and `undefined` is returned.
+ *
+ * @param proxyOverride - Optional explicit proxy URL to use instead of environment variables.
+ * @returns A Node `Agent` configured for the proxy, or `undefined` when no valid proxy is available or agent creation fails.
+ */
+export function getProxyAgent(proxyOverride?: string): Agent | undefined {
+  const proxyUrl = getProxyUrl(proxyOverride);
+  
+  if (!proxyUrl) {
+    return undefined;
+  }
+  
+  if (!isValidProxyUrl(proxyUrl)) {
+    console.error(`Invalid proxy URL: ${sanitizeProxyUrl(proxyUrl)}`);
+    return undefined;
+  }
+  
+  try {
+    // Create appropriate agent based on proxy type
+    if (getProxyType(proxyUrl) === 'socks') {
+      return new SocksProxyAgent(proxyUrl);
+    } else {
+      return new HttpsProxyAgent(proxyUrl);
+    }
+  } catch (error) {
+    console.error(`Failed to create proxy agent: ${sanitizeProxyUrl(proxyUrl)}`);
+    return undefined;
+  }
+}
+
+/**
+ * Returns information about the configured proxy (from an explicit override or environment).
+ *
+ * If a proxy URL is found returns an object with `enabled: true`, a sanitized `url` (credentials removed or obfuscated) and the proxy `type` (`'socks'` or `'http'`). If no proxy is configured returns `{ enabled: false }`.
+ *
+ * The `enabled` field indicates whether the proxy URL is valid and usable.
+ *
+ * @param proxyOverride - Optional explicit proxy URL to use instead of environment variables.
+ */
+export function getProxyInfo(proxyOverride?: string): { enabled: boolean; url?: string; type?: string } {
+  const proxyUrl = getProxyUrl(proxyOverride);
+  
+  if (!proxyUrl) {
+    return { enabled: false };
+  }
+  
+  const isValid = isValidProxyUrl(proxyUrl);
+  // Return info for debugging even if URL is invalid, but enabled reflects validity
+  return {
+    enabled: isValid,
+    url: sanitizeProxyUrl(proxyUrl),
+    type: getProxyType(proxyUrl)
+  };
+}

--- a/test/agent-context-load.test.ts
+++ b/test/agent-context-load.test.ts
@@ -1,0 +1,56 @@
+import test from 'ava';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Agent } from '../src/core/agent.js';
+
+function setupDirWithContext(): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'groq-agentctx-'));
+  const ctxDir = path.join(tmp, '.groq');
+  fs.mkdirSync(ctxDir);
+  fs.writeFileSync(path.join(ctxDir, 'context.md'), 'HelloCtx\n');
+  return tmp;
+}
+
+function cleanupDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+test('Agent auto-loads .groq/context.md as system message', async t => {
+  const dir = setupDirWithContext();
+  const original = { ...process.env };
+  (process.env as any).GROQ_CONTEXT_DIR = dir;
+  try {
+    const agent = await Agent.create('test-model', 1.0, null, false);
+    const msgs = (agent as any).messages as Array<{ role: string; content: string }>;
+    const found = msgs.find(m => m.role === 'system' && m.content.includes('Project context loaded from .groq/context.md'));
+    t.truthy(found);
+    t.true(found!.content.includes('HelloCtx'));
+  } finally {
+    // restore env
+    for (const k of Object.keys(process.env)) delete (process.env as any)[k];
+    Object.assign(process.env, original);
+    cleanupDir(dir);
+  }
+});
+
+test('Agent handles missing context gracefully', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'groq-nocontext-'));
+  const original = { ...process.env };
+  (process.env as any).GROQ_CONTEXT_DIR = dir;
+  try {
+    const agent = await Agent.create('test-model', 1.0, null, false);
+    const msgs = (agent as any).messages as Array<{ role: string; content: string }>;
+    // Should only have the default system message
+    t.is(msgs.filter(m => m.role === 'system').length, 1);
+    t.false(msgs[0].content.includes('Project context loaded'));
+  } finally {
+    for (const k of Object.keys(process.env)) delete (process.env as any)[k];
+    Object.assign(process.env, original);
+    cleanupDir(dir);
+  }
+});

--- a/test/context-generator.test.ts
+++ b/test/context-generator.test.ts
@@ -1,0 +1,66 @@
+import test from 'ava';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { generateProjectContext, writeProjectContext } from '../src/utils/context.js';
+
+function makeTempProject(): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'groq-context-'));
+  // Create files and dirs
+  fs.mkdirSync(path.join(tmp, 'src'));
+  fs.mkdirSync(path.join(tmp, 'docs'));
+  fs.writeFileSync(path.join(tmp, 'src', 'index.ts'), 'export const x = 1;\n');
+  fs.writeFileSync(path.join(tmp, 'README.md'), '# Readme\n');
+  fs.writeFileSync(path.join(tmp, 'docs', 'guide.md'), '# Guide\n');
+  fs.writeFileSync(
+    path.join(tmp, 'package.json'),
+    JSON.stringify({ name: 'tmp-proj', version: '0.1.0', scripts: { build: 'tsc' } }, null, 2),
+    'utf-8'
+  );
+  return tmp;
+}
+
+function cleanupTempDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+test('generateProjectContext returns summary, languages, and lists', t => {
+  const root = makeTempProject();
+  try {
+    const { json, markdown } = generateProjectContext(root, { maxDepth: 4 });
+
+    t.truthy(json.generated_at);
+    t.is(json.root, path.resolve(root));
+    t.true(json.summary.total_files >= 3);
+    t.true(json.summary.total_directories >= 2);
+    t.true(json.summary.languages.length >= 1);
+    t.true(Array.isArray(json.config_files));
+    t.true(Array.isArray(json.notable_files));
+    t.true(Array.isArray(json.tree));
+    t.true(markdown.includes('# Project Context'));
+    t.true(markdown.includes('## Directory Tree'));
+  } finally {
+    cleanupTempDir(root);
+  }
+});
+
+test('writeProjectContext writes .groq/context.{md,json}', t => {
+  const root = makeTempProject();
+  try {
+    const { mdPath, jsonPath } = writeProjectContext(root, { maxDepth: 4 });
+
+    t.true(fs.existsSync(mdPath));
+    t.true(fs.existsSync(jsonPath));
+
+    const md = fs.readFileSync(mdPath, 'utf-8');
+    const obj = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
+    t.true(md.includes('Project Context'));
+    t.is(obj.root, path.resolve(root));
+  } finally {
+    cleanupTempDir(root);
+  }
+});

--- a/test/init-command.test.ts
+++ b/test/init-command.test.ts
@@ -1,0 +1,45 @@
+import test from 'ava';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { initCommand } from '../src/commands/definitions/init.js';
+
+function makeTempProject(): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'groq-initcmd-'));
+  fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'p', version: '0.0.0' }));
+  return tmp;
+}
+
+test('/init command generates context and posts system message', t => {
+  const root = makeTempProject();
+  const messages: any[] = [];
+  const original = process.env.GROQ_CONTEXT_DIR;
+  process.env.GROQ_CONTEXT_DIR = root;
+  try {
+    initCommand.handler({
+      addMessage: (m: any) => messages.push(m),
+      clearHistory: () => {},
+      setShowLogin: () => {},
+    });
+
+    const ctxDir = path.join(root, '.groq');
+    t.true(fs.existsSync(path.join(ctxDir, 'context.md')));
+    t.true(fs.existsSync(path.join(ctxDir, 'context.json')));
+    t.true(fs.statSync(path.join(ctxDir, 'context.md')).size > 0);
+    t.true(fs.statSync(path.join(ctxDir, 'context.json')).size > 0);
+
+    t.true(messages.some(m => m.role === 'system' && String(m.content).includes('Project context generated.')));
+  } finally {
+    if (original === undefined) {
+      delete (process.env as any).GROQ_CONTEXT_DIR;
+    } else {
+      process.env.GROQ_CONTEXT_DIR = original;
+    }
+    // Cleanup temporary project directory
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Add `/init` command to generate `.groq/context.md` and `.groq/context.json` from the current repository (tree, languages, config, notable files, summary)
- Auto-load `.groq/context.md` into the agent at startup as a system message to provide repository grounding
- Register command and include in help/suggestions

## Test plan
- Run `npm run build` (passes)
- Start CLI and run `/init` to create `.groq/context.*`
- Restart CLI; verify initial system messages include the project context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - /init command to generate project context; app auto-loads project context at startup.
  - Proxy support: CLI flag and env var support, persistent proxy setting, and proxy usage in network requests.
  - New /stats command and a Session Stats UI panel; session token/usage tracking and per-session stats display.
  - Error retry overlay to let users retry or cancel failed operations.

- **Documentation**
  - Updated README with proxy configuration, install/run guidance, and new command docs.

- **Chores**
  - Added test npm script and proxy-related dependencies.

- **Tests**
  - Added tests for proxy behavior, context generation/loading, and the /init command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->