### PR TITLE
feat: custom slash commands via local-settings (global+project)

### DIFF
--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -5,16 +5,30 @@ export interface CommandContext {
   setShowModelSelector?: (show: boolean) => void;
   toggleReasoning?: () => void;
   showReasoning?: boolean;
+  // Optional: allow commands to trigger an agent request directly
+  sendMessage?: (message: string) => Promise<void>;
 }
 
 export interface CommandDefinition {
   command: string;
   description: string;
-  handler: (context: CommandContext) => void;
+  handler: (context: CommandContext) => void | Promise<void>;
+  // Optional: if provided, this command is a preset prompt command.
+  // When executed, the system will insert this prompt into the chat as a message
+  // instead of invoking the handler. If both are present, the preset prompt takes precedence.
+  customPrompt?: string;
+  // If true, any text typed after the slash command will be appended to the custom prompt.
+  // Example: "/review src" appends "src" to the preset prompt.
+  appendArgs?: boolean;
+  // Role to use when inserting the custom prompt (defaults to 'user')
+  role?: 'user' | 'system';
 }
 
 export abstract class BaseCommand implements CommandDefinition {
   abstract command: string;
   abstract description: string;
-  abstract handler(context: CommandContext): void;
+  abstract handler(context: CommandContext): void | Promise<void>;
+  customPrompt?: string | undefined;
+  appendArgs?: boolean | undefined;
+  role?: 'user' | 'system' | undefined;
 }

--- a/src/commands/definitions/help.ts
+++ b/src/commands/definitions/help.ts
@@ -24,7 +24,32 @@ Keyboard Shortcuts:
 - Shift+Tab - Toggle auto-approval for editing tools
 - Ctrl+C - Exit the application
 
-This is a highly customizable, lightweight, and open-source coding CLI powered by Groq. Ask for help with coding tasks, debugging issues, or explaining code.`
+This is a highly customizable, lightweight, and open-source coding CLI powered by Groq. Ask for help with coding tasks, debugging issues, or explaining code.
+
+Custom slash commands:
+- Add to global: ~/.groq/local-settings.json
+- Or project: ./.groq/local-settings.json
+
+Notes:
+- Built-in commands cannot be overridden. If a custom command name matches a built-in, it will be ignored.
+- Also supports "prompt" as an alias for "customPrompt".
+- "appendArgs" defaults to false.
+- "role" defaults to "user".
+
+\`\`\`json
+{
+  "customCommands": [
+    {
+      "command": "review",
+      "description": "Review code or a path",
+      "customPrompt": "You are a strict code reviewer. Review the following:",
+      "appendArgs": true,
+      "role": "user"
+    }
+  ]
+}
+\`\`\`
+`
     });
   }
 };

--- a/src/ui/components/core/Chat.tsx
+++ b/src/ui/components/core/Chat.tsx
@@ -103,15 +103,29 @@ export default function Chat({ agent }: ChatProps) {
       
       // Handle slash commands
       if (message.startsWith('/')) {
-        handleSlashCommand(message, {
-          addMessage,
-          clearHistory,
-          setShowLogin,
-          setShowModelSelector,
-          toggleReasoning,
-          showReasoning,
-        });
-        return;
+        try {
+          const handled = await handleSlashCommand(message, {
+            addMessage,
+            clearHistory,
+            setShowLogin,
+            setShowModelSelector,
+            toggleReasoning,
+            showReasoning,
+            sendMessage,
+          });
+          if (handled) {
+            return;
+          }
+          // Unknown slash command: fall back to sending as plain text
+          addMessage({ role: 'system', content: `Unknown command: ${message}. Try /help for available commands.` });
+          return;
+        } catch (err) {
+          addMessage({
+            role: 'system',
+            content: `Error executing command: ${err instanceof Error ? err.message : String(err)}`,
+          });
+          return;
+        }
       }
       
       // The agent will handle starting request tracking

--- a/src/utils/custom-commands.ts
+++ b/src/utils/custom-commands.ts
@@ -1,0 +1,21 @@
+import { ConfigManager } from './local-settings.js';
+
+export interface LoadedCustomCommand {
+  command: string;
+  description?: string;
+  customPrompt?: string;
+  prompt?: string;
+  appendArgs?: boolean;
+  role?: 'user' | 'system';
+}
+
+export function loadCustomCommandsFromSettings(): LoadedCustomCommand[] {
+  try {
+    const manager = new ConfigManager();
+    const cmds = manager.getCustomCommands?.();
+    if (Array.isArray(cmds)) return cmds as LoadedCustomCommand[];
+  } catch (_) {
+    // ignore
+  }
+  return [];
+}

--- a/src/utils/local-settings.ts
+++ b/src/utils/local-settings.ts
@@ -2,9 +2,19 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
+interface CustomCommandConfig {
+  command: string;
+  description?: string;
+  customPrompt?: string; // preferred key
+  prompt?: string;       // alias for customPrompt
+  appendArgs?: boolean;
+  role?: 'user' | 'system';
+}
+
 interface Config {
   groqApiKey?: string;
   defaultModel?: string;
+  customCommands?: CustomCommandConfig[];
 }
 
 const CONFIG_DIR = '.groq'; // In home directory
@@ -12,10 +22,13 @@ const CONFIG_FILE = 'local-settings.json';
 
 export class ConfigManager {
   private configPath: string;
+  private projectConfigPath: string;
 
   constructor() {
     const homeDir = os.homedir();
     this.configPath = path.join(homeDir, CONFIG_DIR, CONFIG_FILE);
+    // Project-level settings: ./.groq/local-settings.json
+    this.projectConfigPath = path.join(process.cwd(), CONFIG_DIR, CONFIG_FILE);
   }
 
   private ensureConfigDir(): void {
@@ -114,6 +127,38 @@ export class ConfigManager {
       });
     } catch (error) {
       throw new Error(`Failed to save default model: ${error}`);
+    }
+  }
+
+  // --- Custom commands ---
+  public getCustomCommands(): CustomCommandConfig[] {
+    try {
+      const project = this.readConfigIfExists(this.projectConfigPath);
+      const global = this.readConfigIfExists(this.configPath);
+      const projectCommands = Array.isArray(project.customCommands) ? project.customCommands : [];
+      const globalCommands = Array.isArray(global.customCommands) ? global.customCommands : [];
+
+      // Merge with project commands taking precedence by command name
+      const map = new Map<string, CustomCommandConfig>();
+      for (const c of globalCommands) {
+        if (c && typeof c.command === 'string') map.set(c.command, c);
+      }
+      for (const c of projectCommands) {
+        if (c && typeof c.command === 'string') map.set(c.command, c);
+      }
+      return Array.from(map.values());
+    } catch (error) {
+      return [];
+    }
+  }
+
+  private readConfigIfExists(filePath: string): Config {
+    try {
+      if (!fs.existsSync(filePath)) return {};
+      const data = fs.readFileSync(filePath, 'utf8');
+      return JSON.parse(data) as Config;
+    } catch {
+      return {};
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add Claude Code-style custom slash commands configurable in local settings
- Read from global (~/.groq/local-settings.json) and project (./.groq/local-settings.json), with project precedence
- Prevent overriding built-ins; ignore clashing custom names
- Execute preset prompts immediately; support appendArgs and role
- Document schema example in /help

## Rationale
Enables teams and individuals to add quick actions and canned prompts without modifying the codebase, matching a common workflow in Cursor/Gemini/Claude Code.

## Scope
- No changes to network, tools, or agent core behavior
- Lightweight utility to read settings; localized changes to commands and help

## Compatibility
- Intentionally compatible with the ongoing local settings PR; loading is isolated in utils and ignores unknown fields

## Test plan
- Add customCommands to ~/.groq/local-settings.json and verify they appear in slash suggestions and run
- Add project-level ./.groq/local-settings.json overriding the same command; verify precedence
- Add a custom command with the same name as a built-in; verify it is ignored
- Run `npm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom slash commands configurable in global and project settings (project overrides global), with safe loading fallback.
  * Preset-prompt commands with optional argument appending and selectable message role (user or system).
  * Slash commands can send messages via the chat send flow, record command usage in the conversation, and support async handlers with improved error handling.

* **Documentation**
  * Expanded help text explaining custom slash commands, where to configure them, and a sample JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->